### PR TITLE
requirements.txt - use correct beautifulsoup4 package name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ validate_email
 tabulate
 appdirs
 humanize
-bs4
+beautifulsoup4
 python-Levenshtein
 prompt_toolkit>=2
 pygments


### PR DESCRIPTION
The package "bs4" is only a placeholder for the actual package
"beautifulsoup4" https://pypi.org/project/bs4/

This fixes a pkg_resources import issue when installing
convey without pip.

---

NOTE: I didn't test the pip installation with this change